### PR TITLE
Fix quotes in DOM JSON

### DIFF
--- a/lib/coprl/presenters/plugins/seating_chart.rb
+++ b/lib/coprl/presenters/plugins/seating_chart.rb
@@ -2,6 +2,7 @@ require_relative 'seating_chart/components/base'
 require_relative 'seating_chart/components/chart'
 require_relative 'seating_chart/components/designer'
 require_relative 'seating_chart/components/event_manager'
+require 'dry/configurable'
 
 module Coprl
   module Presenters

--- a/views/components/application/_event_manager.erb
+++ b/views/components/application/_event_manager.erb
@@ -1,5 +1,5 @@
 <div id="event-manager-<%= comp.mode %>"
      class="v-plugin v-event_manager"
      style="height: 100%"
-     data-plugin-callback='EventManager'
-     data-manager-options='<%= h expand_hash(comp.chart_options).to_json%>'></div>
+     data-plugin-callback="EventManager"
+     data-manager-options="<%= raw h expand_hash(comp.chart_options).to_json %>"></div>

--- a/views/components/application/_seating_chart.erb
+++ b/views/components/application/_seating_chart.erb
@@ -1,10 +1,9 @@
 <form>
-     <div id="seating-chart-<%= comp.id %>"
-          class="v-plugin v-input v-seating_chart"
-          style="height: 100%;"
-          data-plugin-callback='SeatingChart'
-          data-seating-options='<%= h expand_hash(comp.chart_options).to_json%>'
-          data-pricing='<%= comp.pricing.to_json %>'
-          <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>></div>
+  <div id="seating-chart-<%= comp.id %>"
+       class="v-plugin v-input v-seating_chart"
+       style="height: 100%;"
+       data-plugin-callback="SeatingChart"
+       data-seating-options="<%= raw h expand_hash(comp.chart_options).to_json %>"
+       data-pricing="<%= raw h comp.pricing.to_json %>"
+       <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} %>></div>
 </form>
-

--- a/views/components/application/_seating_designer.erb
+++ b/views/components/application/_seating_designer.erb
@@ -1,5 +1,5 @@
 <div id="seating-designer-<%= comp.id %>"
      class="v-plugin v-seating_designer"
      style="height: 100%;"
-     data-plugin-callback='SeatingDesigner'
-     data-designer-options='<%= h expand_hash(comp.chart_options).to_json%>'></div>
+     data-plugin-callback="SeatingDesigner"
+     data-designer-options="<%= raw h expand_hash(comp.chart_options).to_json %>"></div>


### PR DESCRIPTION
Properly escape quotes and other control characters when rendering plugin attributes as JSON within to the DOM.